### PR TITLE
Add/pdf template

### DIFF
--- a/JatsParserPlugin.inc.php
+++ b/JatsParserPlugin.inc.php
@@ -46,7 +46,6 @@ class JatsParserPlugin extends GenericPlugin {
 				HookRegistry::register('Form::config::before', array($this, 'addCitationsFormFields'));
 				HookRegistry::register('Publication::edit', array($this, 'editPublicationReferences'));
 				HookRegistry::register('Publication::edit', array($this, 'createPdfGalley'), HOOK_SEQUENCE_LAST);
-				// Add this hook to initialize citationTableData for new publications
 				HookRegistry::register('Publication::add', array($this, 'initPublicationCitationTable'));
 			}
 
@@ -124,6 +123,7 @@ class JatsParserPlugin extends GenericPlugin {
 		$issue = $issueDao->getById($publication->getData('issueId'), $context->getId());
 		$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
 		$userGroups = $userGroupDao->getByContextId($journal->getId())->toArray();
+		$plugin = PluginRegistry::getPlugin('generic', 'jatsparserplugin');
 
 		$editDecisionDao = DAORegistry::getDAO('EditDecisionDAO');
 		$decisions = $editDecisionDao->getEditorDecisions($submission->getId());
@@ -136,6 +136,7 @@ class JatsParserPlugin extends GenericPlugin {
 		}
 	
 		$metadata = [
+			'citation_style' => $plugin->getSetting($context->getId(), 'citationStyle'),
 			'publication_id' => $publication->getId(),
 			'doi' => $publication->getData('pub-id::doi'),
 			'journal_id' => $journal->getId(),

--- a/JatsParserPlugin.inc.php
+++ b/JatsParserPlugin.inc.php
@@ -136,6 +136,7 @@ class JatsParserPlugin extends GenericPlugin {
 		}
 	
 		$metadata = [
+			'publication_id' => $publication->getId(),
 			'doi' => $publication->getData('pub-id::doi'),
 			'journal_id' => $journal->getId(),
 			'authors' => $publication->getData('authors'),
@@ -347,6 +348,38 @@ class JatsParserPlugin extends GenericPlugin {
 		}
 
 		return false;
+	}
+
+	/**
+	 * @param Journal $context Journal
+	 * @return string
+	 * @brief Retrieve citation style format that should be supported by citeproc-php
+	 * use own format defined in settings if set
+	 * use CitationStyleLanguagePlugin if set
+	 * use vancouver style otherwise
+	 */
+	function getCitationStyle(Journal $context): string {
+
+		$contextId = $context->getId();
+
+		$citationStyle = $this->getSetting($contextId, 'citationStyle');
+
+		if ($citationStyle) return $citationStyle;
+
+		$pluginSettingsDAO = DAORegistry::getDAO('PluginSettingsDAO');
+		$cslPluginSettings = $pluginSettingsDAO->getPluginSettings($contextId, 'CitationStyleLanguagePlugin');
+
+		if ($cslPluginSettings &&
+			array_key_exists('enabled', $cslPluginSettings) &&
+			$cslPluginSettings['enabled'] &&
+			array_key_exists('primaryCitationStyle', $cslPluginSettings) &&
+			$cslPrimaryCitStyle = $cslPluginSettings['primaryCitationStyle']
+		) $citationStyle = $cslPrimaryCitStyle;
+
+		if ($citationStyle) return $citationStyle;
+
+		$lastCslKey = array_key_last(self::getSupportedCitationStyles());
+		return self::getSupportedCitationStyles()[$lastCslKey]['id']; // vancouver
 	}
 
 	/**

--- a/classes/components/forms/Helpers/process_citations.php
+++ b/classes/components/forms/Helpers/process_citations.php
@@ -18,7 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['citationStyleName'])) {
             $citationsArray[$rid] = $customCitation;
         }
 
-        $unifiedArray[$_POST['xmlFilePath']] = $citationsArray;
+        $unifiedArray['fileId'][$_POST['xmlFilePath']] = $citationsArray;
 
         if ($_POST['publicationId']) {
             $citationJsonData = json_encode($unifiedArray);
@@ -26,7 +26,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['citationStyleName'])) {
             // Using DAO to update the setting
             $customPublicationSettingsDao = new CustomPublicationSettingsDAO();
             $customPublicationSettingsDao->updateSetting($_POST['publicationId'], 'jatsParser::citationTableData', $citationJsonData, $_POST['locale_key']);
-            // echo '<pre>' . json_encode($unifiedArray, JSON_PRETTY_PRINT) . '</pre>';
+            //echo '<pre>' . json_encode($unifiedArray, JSON_PRETTY_PRINT) . '</pre>';
         }
     
         header("Location: " . $_SERVER['REQUEST_URI']);

--- a/classes/components/forms/PublicationJATSUploadForm.inc.php
+++ b/classes/components/forms/PublicationJATSUploadForm.inc.php
@@ -5,6 +5,7 @@ require_once __dir__ . '/../../daos/CustomPublicationSettingsDAO.inc.php';
 
 import('lib.pkp.classes.file.PrivateFileManager');
 
+use JATSParser\PDF\PDFConfig\Configuration;
 use PKP\components\forms\TableHTML;
 use PKP\components\forms\FieldHTML;
 use \PKP\components\forms\FormComponent;
@@ -99,7 +100,10 @@ class PublicationJATSUploadForm extends FormComponent {
 				]));
 			}
 		
-			if ($citationStyle === 'apa') {
+			$supportedCitationStyles = Configuration::getSupportedCustomCitationStyles();
+
+			//checking if the citation style is supported (array of supported citation styles is not empty and the citation style is in the array)
+			if ($supportedCitationStyles && in_array(strtolower($citationStyle), $supportedCitationStyles)) {
 				$fileMgr = new PrivateFileManager();
 				$absolutePath = $fileMgr->getBasePath() . DIRECTORY_SEPARATOR . $relativeFilePath;
 				

--- a/classes/components/forms/TableHTML.php
+++ b/classes/components/forms/TableHTML.php
@@ -80,7 +80,7 @@ class TableHTML {
                 }
 
                 // Try to find by just matching the xrefId across any XML path
-                foreach ($this->citationsArray as $xmlPath => $citations) {
+                foreach ($this->citationsArray['fileId'] as $xmlPath => $citations) {
                     if (isset($citations[$xrefId])) {
                         $this->arrayData[$xrefId]['status'] = 'not-default';
                         $this->arrayData[$xrefId]['citationText'] = $citations[$xrefId];


### PR DESCRIPTION
The PDF is now generated correctly with the citations saved in the configuration. In addition, the table is only displayed and the database queries are performed if the citation style is "APA" (other styles may be added in the future, these are defined in the $supportedCustomCitationStyles array in the Configuration class).