### PR TITLE
changes/hook setCitationTableData eliminated, template changes

### DIFF
--- a/classes/components/forms/PublicationJATSUploadForm.inc.php
+++ b/classes/components/forms/PublicationJATSUploadForm.inc.php
@@ -108,12 +108,11 @@ class PublicationJATSUploadForm extends FormComponent {
 				$absolutePath = $fileMgr->getBasePath() . DIRECTORY_SEPARATOR . $relativeFilePath;
 				
 				$customPublicationSettingsDao = new CustomPublicationSettingsDAO();
-				$publicationId = $publication->getId();
 
 				$locale_key = $context->getPrimaryLocale();
 
-				$customCitationData = $customPublicationSettingsDao->getSetting($publicationId, 'jatsParser::citationTableData', $locale_key); //get jatsParser::citationTableData from database from "publication_settings" table
-				$tableHTML = new TableHTML($citationStyle, $absolutePath, $customCitationData, $publicationId, $locale_key);
+				$customCitationData = $customPublicationSettingsDao->getSetting($publication->getId(), 'jatsParser::citationTableData', $locale_key); //get jatsParser::citationTableData from database from "publication_settings" table
+				$tableHTML = new TableHTML($citationStyle, $absolutePath, $customCitationData, $publication, $locale_key);
 				
 				$html = $tableHTML->getHtml();
 				

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -154,3 +154,6 @@ msgstr "References"
 
 msgid "plugins.generic.jatsParser.figure.title"
 msgstr "Figure"
+
+msgid "plugins.generic.jatsParser.table.title"
+msgstr "Table"

--- a/locale/es_ES/locale.po
+++ b/locale/es_ES/locale.po
@@ -172,3 +172,6 @@ msgstr "Referencias"
 
 msgid "plugins.generic.jatsParser.figure.title"
 msgstr "Figura"
+
+msgid "plugins.generic.jatsParser.table.title"
+msgstr "Tabla"


### PR DESCRIPTION
Se elminó el hook que creaba un nuevo setting_name (en la tabla publication_settings de la base de datos) bajo el nombre de "jatsParser::CitationTableData". 
Este setting_name se creaba luego de realizar un envío de un artículo. Ahora, esta configuración se crea/actualiza al momento de guardar las citas desde la tabla de citaciones.