### PR TITLE
Fix: hardening de JatsParser para PHP 8 (null-safety, Smarty compile dir, citationStyle fallback y fixes de rendering)

### DIFF
--- a/JatsParserPlugin.inc.php
+++ b/JatsParserPlugin.inc.php
@@ -387,7 +387,7 @@ class JatsParserPlugin extends GenericPlugin
 		$metadata = [
 			'publication_pages' => $publication->getData('pages'),
 			'section_title' => $section?->getLocalizedTitle(),
-			'citation_style' => $plugin->getSetting($context->getId(), 'citationStyle'),
+			'citation_style' => $plugin->getCitationStyle($context),
 			'publication_id' => $publication->getId(),
 			'doi' => $publication->getDoi(),
 			'journal_id' => $journal->getId(),
@@ -1130,7 +1130,7 @@ class JatsParserPlugin extends GenericPlugin
 		$numberedCitations = Configuration::getNumberedReferences();
 		$context = Application::get()->getRequest()->getContext();
 		$plugin = PluginRegistry::getPlugin('generic', 'jatsparserplugin'); /* @var $plugin JATSParserPlugin */
-		$citationStyle = $plugin->getSetting($context->getId(), 'citationStyle');
+		$citationStyle = $plugin->getCitationStyle($context);
 
 		//Obtain xml jats file
 		// Create a JATSDocument instance
@@ -1145,7 +1145,7 @@ class JatsParserPlugin extends GenericPlugin
 
 		//$locale_key = $context->getPrimaryLocale();
 		$formattedLocaleKey = str_replace('_', '-', $locale);
-		$citationStyle = $plugin->getSetting($context->getId(), 'citationStyle');
+		// $citationStyle ya fue obtenido arriba con getCitationStyle(), no es necesario releerlo.
 		$dateFormat = $context->getSetting('dateFormatShort');
 		if (is_array($dateFormat)) {
 			// Extract date format based on PUBLICATION locale (article language), not galley locale

--- a/JatsParserPlugin.inc.php
+++ b/JatsParserPlugin.inc.php
@@ -371,9 +371,12 @@ class JatsParserPlugin extends GenericPlugin
 			$licenseUrl .= "/";
 		}
 
-		// Separar por "/"
-		list($anio, $mes, $dia) = explode('/', str_replace('-', '/', $submission->getDatePublished()));
-		// Reordenar como día/mes/año
+		// Separar por "/" y reordenar como día/mes/año de forma segura
+		$date = $submission->getDatePublished();
+		$partes = $date ? explode('/', str_replace('-', '/', $date)) : [];
+		$anio = $partes[0] ?? '';
+		$mes  = $partes[1] ?? '';
+		$dia  = $partes[2] ?? '';
 		$datePublished = ($dia && $mes && $anio) ? "$dia/$mes/$anio" : '';
 
 		$authors = array_values(iterator_to_array($publication->getData('authors')));

--- a/templates/SUMARC/UNLP/footer.tpl
+++ b/templates/SUMARC/UNLP/footer.tpl
@@ -5,7 +5,7 @@
     <table class="footer-table">
         <tr>
             <td class="footer-section-title">
-                {call name="getMetadata" search={$section_title}}
+                {if isset($section_title)}{call name="getMetadata" search=$section_title}{/if}
             </td>
             <td class="footer-page-number">
                 <pagenumber />

--- a/templates/SUMARC/UNLP/footer.tpl
+++ b/templates/SUMARC/UNLP/footer.tpl
@@ -5,7 +5,7 @@
     <table class="footer-table">
         <tr>
             <td class="footer-section-title">
-                {if isset($section_title)}{call name="getMetadata" search=$section_title}{/if}
+                {call name="getMetadata" search={$section_title}}
             </td>
             <td class="footer-page-number">
                 <pagenumber />

--- a/templates/SUMARC/UNLP/footnotes.tpl
+++ b/templates/SUMARC/UNLP/footnotes.tpl
@@ -8,4 +8,4 @@
   {/if}
 </style>
 
-<h2 class="footnotes-title">{if isset($translations.$locale_key.footnotes)}{$translations.$locale_key.footnotes}{/if}</h2>
+<h2 class="footnotes-title">{$translations.{$locale_key}.footnotes}</h2>

--- a/templates/SUMARC/UNLP/footnotes.tpl
+++ b/templates/SUMARC/UNLP/footnotes.tpl
@@ -8,4 +8,4 @@
   {/if}
 </style>
 
-<h2 class="footnotes-title">{$translations.{$locale_key}.footnotes}</h2>
+<h2 class="footnotes-title">{if isset($translations.$locale_key.footnotes)}{$translations.$locale_key.footnotes}{/if}</h2>

--- a/templates/SUMARC/UNLP/frontpage.tpl
+++ b/templates/SUMARC/UNLP/frontpage.tpl
@@ -84,7 +84,9 @@
 
         <div class="frontpage-article-body">
             {call name="getMetadata" pre="<h3 class='frontpage-article-title'>" search={$article_title} post="</h3>"}
-            {call name="getMetadata" pre="<h4 class='frontpage-article-subtitle'>" search={$subtitles.{$locale_key}} post="</h4>"}
+            {if is_array($subtitles) && isset($subtitles.$locale_key)}
+                {call name="getMetadata" pre="<h4 class='frontpage-article-subtitle'>" search=$subtitles.$locale_key post="</h4>"}
+            {/if}
 
             {foreach from=$lang_keys item=key name=keys}
                 {if $locale_key != $key && ( (isset($titles.$key) && $titles.$key) || (isset($subtitles.$key) && $subtitles.$key) )}

--- a/templates/SUMARC/UNLP/frontpage.tpl
+++ b/templates/SUMARC/UNLP/frontpage.tpl
@@ -84,15 +84,15 @@
 
         <div class="frontpage-article-body">
             {call name="getMetadata" pre="<h3 class='frontpage-article-title'>" search={$article_title} post="</h3>"}
-            {if is_array($subtitles) && isset($subtitles.$locale_key)}
+            {if isset($subtitles.$locale_key)}
                 {call name="getMetadata" pre="<h4 class='frontpage-article-subtitle'>" search=$subtitles.$locale_key post="</h4>"}
             {/if}
 
             {foreach from=$lang_keys item=key name=keys}
                 {if $locale_key != $key && ( (isset($titles.$key) && $titles.$key) || (isset($subtitles.$key) && $subtitles.$key) )}
                     <h5 class="frontpage-article-lang-title">
-                        {call name="getMetadata" pre="<span>" search={$titles.{$key}} post="</span>."}
-                        {call name="getMetadata" pre="<span>" search={$subtitles.{$key}} post="</span>"}
+                        {call name="getMetadata" pre="<span>" search=$titles.$key post="</span>."}
+                        {call name="getMetadata" pre="<span>" search=$subtitles.$key post="</span>"}
                     </h5>
                 {/if}
             {/foreach}

--- a/templates/SUMARC/UNLP/frontpage.tpl
+++ b/templates/SUMARC/UNLP/frontpage.tpl
@@ -15,11 +15,11 @@
                 <tr>
                     <td class="frontpage-logo-cell">
                         <div class="frontpage-journal-logos">
-                            {call name="getImage" 
+                            {if isset($journal_logo)}{call name="getImage" 
                                 pre="<img src='"
-                                search={$journal_logo}
+                                search=$journal_logo
                                 post="' class='frontpage-journal-logo'>"
-                            }
+                            }{/if}
                         </div>
                     </td>
                     <td class="frontpage-journal-info-cell">
@@ -27,41 +27,41 @@
                             <table class="frontpage-journal-info-table">
                                 <tr>
                                     <td class="frontpage-journal-info-line">
-                                        {call name="getMetadata" search={$journal_title}}
+                                        {if isset($journal_title)}{call name="getMetadata" search=$journal_title}{/if}
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
-                                        {call name="getMetadata" pre="{$translations.{$locale_key}.volume} " search={$issue_volume} post=", "}
-                                        {call name="getMetadata" pre="{$translations.{$locale_key}.number} " search={$issue_number} post=", "}
-                                        {call name="getMetadata" search={$publication_pages} post=", "}
-                                        {call name="getMetadata" search={$section_title} post=", "}
-                                        {call name="getMetadata" search={$issue_year}}
+                                        {if isset($issue_volume)}{call name="getMetadata" pre="{$translations.$locale_key.volume} " search=$issue_volume post=", "}{/if}
+                                        {if isset($issue_number)}{call name="getMetadata" pre="{$translations.$locale_key.number} " search=$issue_number post=", "}{/if}
+                                        {if isset($publication_pages)}{call name="getMetadata" search=$publication_pages post=", "}{/if}
+                                        {if isset($section_title)}{call name="getMetadata" search=$section_title post=", "}{/if}
+                                        {if isset($issue_year)}{call name="getMetadata" search=$issue_year}{/if}
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
                                         <div class='frontpage-anchor'>
-                                            {call name="getLinkedMetadata" preOne="<a href='https://doi.org/" preTwo="'class='frontpage-anchor'>https://doi.org/" search={$doi} post="</a>"}
+                                            {if isset($doi)}{call name="getLinkedMetadata" preOne="<a href='https://doi.org/" preTwo="'class='frontpage-anchor'>https://doi.org/" search=$doi post="</a>"}{/if}
                                         </div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
                                         <div class="frontpage-anchor">
-                                            {call name="getMetadata" pre="<span class='frontpage-issn'>ISSN " search={$online_issn} post="</span>"} 
+                                            {if isset($online_issn)}{call name="getMetadata" pre="<span class='frontpage-issn'>ISSN " search=$online_issn post="</span>"}{/if} 
                                             {if isset($online_issn) && $online_issn && isset($journal_url) && $journal_url}
                                                 <span class="frontpage-separator"> | </span>
                                             {/if}
-                                            {call name="getLinkedMetadata" preOne="<a href='" preTwo="'class='frontpage-anchor'>" search={$journal_url} post="</a>"}
+                                            {if isset($journal_url)}{call name="getLinkedMetadata" preOne="<a href='" preTwo="'class='frontpage-anchor'>" search=$journal_url post="</a>"}{/if}
                                         </div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
-                                        {call name="getMetadata" pre="{$translations.{$locale_key}.received}: " search={$date_submitted}}
-                                        {call name="getMetadata" pre=" - {$translations.{$locale_key}.accepted}: " search={$date_accepted}}
-                                        {call name="getMetadata" pre=" - {$translations.{$locale_key}.published}: " search={$date_published}}
+                                        {if isset($date_submitted)}{call name="getMetadata" pre="{$translations.$locale_key.received}: " search=$date_submitted}{/if}
+                                        {if isset($date_accepted)}{call name="getMetadata" pre=" - {$translations.$locale_key.accepted}: " search=$date_accepted}{/if}
+                                        {if isset($date_published)}{call name="getMetadata" pre=" - {$translations.$locale_key.published}: " search=$date_published}{/if}
                                     </td>
                                 </tr>
                             </table>
@@ -76,14 +76,14 @@
                         <hr class="frontpage-hr">
                     </td>
                     <td class="frontpage-institution-logo-cell">
-                        {call name='getImage' pre="<img src='" search={$institution_logo} post="' class='frontpage-institution-logo'>"}
+                        {if isset($institution_logo)}{call name='getImage' pre="<img src='" search=$institution_logo post="' class='frontpage-institution-logo'>"}{/if}
                     </td>
                 </tr>
             </table>
         </header>
 
         <div class="frontpage-article-body">
-            {call name="getMetadata" pre="<h3 class='frontpage-article-title'>" search={$article_title} post="</h3>"}
+            {if isset($article_title)}{call name="getMetadata" pre="<h3 class='frontpage-article-title'>" search=$article_title post="</h3>"}{/if}
             {if isset($subtitles.$locale_key)}
                 {call name="getMetadata" pre="<h4 class='frontpage-article-subtitle'>" search=$subtitles.$locale_key post="</h4>"}
             {/if}
@@ -91,8 +91,8 @@
             {foreach from=$lang_keys item=key name=keys}
                 {if $locale_key != $key && ( (isset($titles.$key) && $titles.$key) || (isset($subtitles.$key) && $subtitles.$key) )}
                     <h5 class="frontpage-article-lang-title">
-                        {call name="getMetadata" pre="<span>" search=$titles.$key post="</span>."}
-                        {call name="getMetadata" pre="<span>" search=$subtitles.$key post="</span>"}
+                        {if isset($titles.$key)}{call name="getMetadata" pre="<span>" search=$titles.$key post="</span>."}{/if}
+                        {if isset($subtitles.$key)}{call name="getMetadata" pre="<span>" search=$subtitles.$key post="</span>"}{/if}
                     </h5>
                 {/if}
             {/foreach}
@@ -103,23 +103,25 @@
                         <table style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 0; vertical-align: middle;">
+                                    {if isset($author.orcid)}
                                     {call name="getDoubleMetadata"
-                                        preOne="<a class='frontpage-anchor' href='" searchOne="{$author.orcid}" postOne="'>"
-                                        preTwo="<img src='" searchTwo="{$orcid_logo.white_bg}" postTwo="' class='frontpage-orcid-logo'></a>"
+                                        preOne="<a class='frontpage-anchor' href='" searchOne=$author.orcid postOne="'>"
+                                        preTwo="<img src='" searchTwo=$orcid_logo.white_bg postTwo="' class='frontpage-orcid-logo'></a>"
                                     }
+                                    {/if}
                                 </td>
                                 <td style="padding: 0; vertical-align: middle;">
                                     <div class="frontpage-author-name-colored">
-                                        {call name="getMetadata" search={$author.givenName.{$article_locale_key}}}
-                                        {call name="getMetadata" search={$author.familyName.{$article_locale_key}}}
+                                        {if isset($author.givenName.$article_locale_key)}{call name="getMetadata" search=$author.givenName.$article_locale_key}{/if}
+                                        {if isset($author.familyName.$article_locale_key)}{call name="getMetadata" search=$author.familyName.$article_locale_key}{/if}
                                     </div>
                                 </td>
                             </tr>
                         </table>
                         <div class="frontpage-author-contact">
-                            {call name="getLinkedMetadata" preOne="<a href='mailto:'" preTwo="class='frontpage-anchor'>" search=$author.email post="</a>"}
+                            {if isset($author.email)}{call name="getLinkedMetadata" preOne="<a href='mailto:'" preTwo="class='frontpage-anchor'>" search=$author.email post="</a>"}{/if}
                         </div>
-                        {call name="getMetadata" pre="<div class='frontpage-author-affiliation'>" search={$author.affiliation.{$article_locale_key}} post="</div>"}
+                        {if isset($author.affiliation.$article_locale_key)}{call name="getMetadata" pre="<div class='frontpage-author-affiliation'>" search=$author.affiliation.$article_locale_key post="</div>"}{/if}
                     </div>
                 {/foreach}
             </div>
@@ -128,50 +130,60 @@
 
             <div class="frontpage-abstract-section">
                 <span>
-                    {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.{$locale_key}.abstract} | </span> <span class='frontpage-abstract-text'>" search={$abstract_texts.{$locale_key}} post="</span>"}
+                    {if isset($abstract_texts.$locale_key)}{call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.$locale_key.abstract} | </span> <span class='frontpage-abstract-text'>" search=$abstract_texts.$locale_key post="</span>"}{/if}
                 </span>
             </div>
+            {if isset($keywords_texts.$locale_key)}
             <div class="frontpage-keywords-container">
-                {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.{$locale_key}.keywords} | </span>" search="{$keywords_texts.{$locale_key}}"}
+                {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.$locale_key.keywords} | </span>" search=$keywords_texts.$locale_key}
                 <span class="frontpage-keywords-list">
-                    {foreach from=$keywords_texts.{$locale_key} item=keyword name=keywords}
-                        {call name="getMetadata" pre="<span class='frontpage-keyword'>" search={$keyword} post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}
+                    {foreach from=$keywords_texts.$locale_key item=keyword name=keywords}
+                        {if isset($keyword)}{call name="getMetadata" pre="<span class='frontpage-keyword'>" search=$keyword post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}{/if}
                     {/foreach}
                 </span>
             </div>
+            {/if}
 
             {foreach from=$lang_keys item=key name=keys}
                 {if $locale_key != $key}
+                    {if isset($abstract_texts.$key)}
                     <div class="frontpage-abstract-section">
                         <span>
-                            {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.{$key}.abstract} | </span> <span class='frontpage-abstract-text'>" search={$abstract_texts.{$key}} post="</span>"}
+                            {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.$key.abstract} | </span> <span class='frontpage-abstract-text'>" search=$abstract_texts.$key post="</span>"}
                         </span>
                     </div>
+                    {/if}
+                    {if isset($keywords_texts.$key)}
                     <div class="frontpage-keywords-container">
-                        {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.{$key}.keywords} | </span>" search="{$keywords_texts.{$key}}"}
+                        {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.$key.keywords} | </span>" search=$keywords_texts.$key}
                         <span class="frontpage-keywords-list">
-                            {foreach from=$keywords_texts.{$key} item=keyword name=keywords}
-                                {call name="getMetadata" pre="<span class='frontpage-keyword'>" search={$keyword} post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}
+                            {foreach from=$keywords_texts.$key item=keyword name=keywords}
+                                {if isset($keyword)}{call name="getMetadata" pre="<span class='frontpage-keyword'>" search=$keyword post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}{/if}
                             {/foreach}
                         </span>
                     </div>
+                    {/if}
                 {/if}
             {/foreach}
 
             <table class="frontpage-license-info" style="width: 100%; border-collapse: collapse; margin-top: 0px;">
                 <tr>
                     <td style="width: 40px; vertical-align: middle;">
+                        {if isset($license_url) && isset($license_logo)}
                         {call name="getDoubleMetadata"
-                            preOne="<a href='" searchOne={$license_url} postOne="'class='frontpage-anchor'>"
-                            preTwo="<img src='" searchTwo={$license_logo} postTwo="'class='frontpage-license-image'></a>"
+                            preOne="<a href='" searchOne=$license_url postOne="'class='frontpage-anchor'>"
+                            preTwo="<img src='" searchTwo=$license_logo postTwo="'class='frontpage-license-image'></a>"
                         }
+                        {/if}
                     </td>
                     <td style="vertical-align: middle; padding-left: 10px;">
                         <div class="frontpage-license-text">
+                            {if isset($license_url) && isset($translations.$locale_key.license_text)}
                             {call name="getDoubleMetadata"
-                                preOne="<a href='" searchOne={$license_url} postOne="' class='frontpage-anchor'>"
-                                preTwo="" searchTwo="{$translations.{$locale_key}.license_text}" postTwo='</a>'
+                                preOne="<a href='" searchOne=$license_url postOne="' class='frontpage-anchor'>"
+                                preTwo="" searchTwo=$translations.$locale_key.license_text postTwo='</a>'
                             }
+                            {/if}
                         </div>
                     </td>
                 </tr>

--- a/templates/SUMARC/UNLP/frontpage.tpl
+++ b/templates/SUMARC/UNLP/frontpage.tpl
@@ -15,11 +15,11 @@
                 <tr>
                     <td class="frontpage-logo-cell">
                         <div class="frontpage-journal-logos">
-                            {if isset($journal_logo)}{call name="getImage" 
+                            {call name="getImage" 
                                 pre="<img src='"
-                                search=$journal_logo
+                                search={$journal_logo}
                                 post="' class='frontpage-journal-logo'>"
-                            }{/if}
+                            }
                         </div>
                     </td>
                     <td class="frontpage-journal-info-cell">
@@ -27,41 +27,41 @@
                             <table class="frontpage-journal-info-table">
                                 <tr>
                                     <td class="frontpage-journal-info-line">
-                                        {if isset($journal_title)}{call name="getMetadata" search=$journal_title}{/if}
+                                        {call name="getMetadata" search={$journal_title}}
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
-                                        {if isset($issue_volume)}{call name="getMetadata" pre="{$translations.$locale_key.volume} " search=$issue_volume post=", "}{/if}
-                                        {if isset($issue_number)}{call name="getMetadata" pre="{$translations.$locale_key.number} " search=$issue_number post=", "}{/if}
-                                        {if isset($publication_pages)}{call name="getMetadata" search=$publication_pages post=", "}{/if}
-                                        {if isset($section_title)}{call name="getMetadata" search=$section_title post=", "}{/if}
-                                        {if isset($issue_year)}{call name="getMetadata" search=$issue_year}{/if}
+                                        {call name="getMetadata" pre="{$translations.{$locale_key}.volume} " search={$issue_volume} post=", "}
+                                        {call name="getMetadata" pre="{$translations.{$locale_key}.number} " search={$issue_number} post=", "}
+                                        {call name="getMetadata" search={$publication_pages} post=", "}
+                                        {call name="getMetadata" search={$section_title} post=", "}
+                                        {call name="getMetadata" search={$issue_year}}
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
                                         <div class='frontpage-anchor'>
-                                            {if isset($doi)}{call name="getLinkedMetadata" preOne="<a href='https://doi.org/" preTwo="'class='frontpage-anchor'>https://doi.org/" search=$doi post="</a>"}{/if}
+                                            {call name="getLinkedMetadata" preOne="<a href='https://doi.org/" preTwo="'class='frontpage-anchor'>https://doi.org/" search={$doi} post="</a>"}
                                         </div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
                                         <div class="frontpage-anchor">
-                                            {if isset($online_issn)}{call name="getMetadata" pre="<span class='frontpage-issn'>ISSN " search=$online_issn post="</span>"}{/if} 
+                                            {call name="getMetadata" pre="<span class='frontpage-issn'>ISSN " search={$online_issn} post="</span>"} 
                                             {if isset($online_issn) && $online_issn && isset($journal_url) && $journal_url}
                                                 <span class="frontpage-separator"> | </span>
                                             {/if}
-                                            {if isset($journal_url)}{call name="getLinkedMetadata" preOne="<a href='" preTwo="'class='frontpage-anchor'>" search=$journal_url post="</a>"}{/if}
+                                            {call name="getLinkedMetadata" preOne="<a href='" preTwo="'class='frontpage-anchor'>" search={$journal_url} post="</a>"}
                                         </div>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
-                                        {if isset($date_submitted)}{call name="getMetadata" pre="{$translations.$locale_key.received}: " search=$date_submitted}{/if}
-                                        {if isset($date_accepted)}{call name="getMetadata" pre=" - {$translations.$locale_key.accepted}: " search=$date_accepted}{/if}
-                                        {if isset($date_published)}{call name="getMetadata" pre=" - {$translations.$locale_key.published}: " search=$date_published}{/if}
+                                        {call name="getMetadata" pre="{$translations.{$locale_key}.received}: " search={$date_submitted}}
+                                        {call name="getMetadata" pre=" - {$translations.{$locale_key}.accepted}: " search={$date_accepted}}
+                                        {call name="getMetadata" pre=" - {$translations.{$locale_key}.published}: " search={$date_published}}
                                     </td>
                                 </tr>
                             </table>
@@ -76,14 +76,14 @@
                         <hr class="frontpage-hr">
                     </td>
                     <td class="frontpage-institution-logo-cell">
-                        {if isset($institution_logo)}{call name='getImage' pre="<img src='" search=$institution_logo post="' class='frontpage-institution-logo'>"}{/if}
+                        {call name='getImage' pre="<img src='" search={$institution_logo} post="' class='frontpage-institution-logo'>"}
                     </td>
                 </tr>
             </table>
         </header>
 
         <div class="frontpage-article-body">
-            {if isset($article_title)}{call name="getMetadata" pre="<h3 class='frontpage-article-title'>" search=$article_title post="</h3>"}{/if}
+            {call name="getMetadata" pre="<h3 class='frontpage-article-title'>" search={$article_title} post="</h3>"}
             {if isset($subtitles.$locale_key)}
                 {call name="getMetadata" pre="<h4 class='frontpage-article-subtitle'>" search=$subtitles.$locale_key post="</h4>"}
             {/if}
@@ -91,8 +91,8 @@
             {foreach from=$lang_keys item=key name=keys}
                 {if $locale_key != $key && ( (isset($titles.$key) && $titles.$key) || (isset($subtitles.$key) && $subtitles.$key) )}
                     <h5 class="frontpage-article-lang-title">
-                        {if isset($titles.$key)}{call name="getMetadata" pre="<span>" search=$titles.$key post="</span>."}{/if}
-                        {if isset($subtitles.$key)}{call name="getMetadata" pre="<span>" search=$subtitles.$key post="</span>"}{/if}
+                        {call name="getMetadata" pre="<span>" search=$titles.$key post="</span>."}
+                        {call name="getMetadata" pre="<span>" search=$subtitles.$key post="</span>"}
                     </h5>
                 {/if}
             {/foreach}
@@ -103,25 +103,23 @@
                         <table style="border-collapse: collapse;">
                             <tr>
                                 <td style="padding: 0; vertical-align: middle;">
-                                    {if isset($author.orcid)}
                                     {call name="getDoubleMetadata"
-                                        preOne="<a class='frontpage-anchor' href='" searchOne=$author.orcid postOne="'>"
-                                        preTwo="<img src='" searchTwo=$orcid_logo.white_bg postTwo="' class='frontpage-orcid-logo'></a>"
+                                        preOne="<a class='frontpage-anchor' href='" searchOne="{$author.orcid}" postOne="'>"
+                                        preTwo="<img src='" searchTwo="{$orcid_logo.white_bg}" postTwo="' class='frontpage-orcid-logo'></a>"
                                     }
-                                    {/if}
                                 </td>
                                 <td style="padding: 0; vertical-align: middle;">
                                     <div class="frontpage-author-name-colored">
-                                        {if isset($author.givenName.$article_locale_key)}{call name="getMetadata" search=$author.givenName.$article_locale_key}{/if}
-                                        {if isset($author.familyName.$article_locale_key)}{call name="getMetadata" search=$author.familyName.$article_locale_key}{/if}
+                                        {call name="getMetadata" search={$author.givenName.{$article_locale_key}}}
+                                        {call name="getMetadata" search={$author.familyName.{$article_locale_key}}}
                                     </div>
                                 </td>
                             </tr>
                         </table>
                         <div class="frontpage-author-contact">
-                            {if isset($author.email)}{call name="getLinkedMetadata" preOne="<a href='mailto:'" preTwo="class='frontpage-anchor'>" search=$author.email post="</a>"}{/if}
+                            {call name="getLinkedMetadata" preOne="<a href='mailto:'" preTwo="class='frontpage-anchor'>" search=$author.email post="</a>"}
                         </div>
-                        {if isset($author.affiliation.$article_locale_key)}{call name="getMetadata" pre="<div class='frontpage-author-affiliation'>" search=$author.affiliation.$article_locale_key post="</div>"}{/if}
+                        {call name="getMetadata" pre="<div class='frontpage-author-affiliation'>" search={$author.affiliation.{$article_locale_key}} post="</div>"}
                     </div>
                 {/foreach}
             </div>
@@ -130,60 +128,50 @@
 
             <div class="frontpage-abstract-section">
                 <span>
-                    {if isset($abstract_texts.$locale_key)}{call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.$locale_key.abstract} | </span> <span class='frontpage-abstract-text'>" search=$abstract_texts.$locale_key post="</span>"}{/if}
+                    {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.{$locale_key}.abstract} | </span> <span class='frontpage-abstract-text'>" search={$abstract_texts.{$locale_key}} post="</span>"}
                 </span>
             </div>
-            {if isset($keywords_texts.$locale_key)}
             <div class="frontpage-keywords-container">
-                {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.$locale_key.keywords} | </span>" search=$keywords_texts.$locale_key}
+                {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.{$locale_key}.keywords} | </span>" search="{$keywords_texts.{$locale_key}}"}
                 <span class="frontpage-keywords-list">
-                    {foreach from=$keywords_texts.$locale_key item=keyword name=keywords}
-                        {if isset($keyword)}{call name="getMetadata" pre="<span class='frontpage-keyword'>" search=$keyword post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}{/if}
+                    {foreach from=$keywords_texts.{$locale_key} item=keyword name=keywords}
+                        {call name="getMetadata" pre="<span class='frontpage-keyword'>" search={$keyword} post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}
                     {/foreach}
                 </span>
             </div>
-            {/if}
 
             {foreach from=$lang_keys item=key name=keys}
                 {if $locale_key != $key}
-                    {if isset($abstract_texts.$key)}
                     <div class="frontpage-abstract-section">
                         <span>
-                            {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.$key.abstract} | </span> <span class='frontpage-abstract-text'>" search=$abstract_texts.$key post="</span>"}
+                            {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.{$key}.abstract} | </span> <span class='frontpage-abstract-text'>" search={$abstract_texts.{$key}} post="</span>"}
                         </span>
                     </div>
-                    {/if}
-                    {if isset($keywords_texts.$key)}
                     <div class="frontpage-keywords-container">
-                        {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.$key.keywords} | </span>" search=$keywords_texts.$key}
+                        {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.{$key}.keywords} | </span>" search="{$keywords_texts.{$key}}"}
                         <span class="frontpage-keywords-list">
-                            {foreach from=$keywords_texts.$key item=keyword name=keywords}
-                                {if isset($keyword)}{call name="getMetadata" pre="<span class='frontpage-keyword'>" search=$keyword post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}{/if}
+                            {foreach from=$keywords_texts.{$key} item=keyword name=keywords}
+                                {call name="getMetadata" pre="<span class='frontpage-keyword'>" search={$keyword} post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}
                             {/foreach}
                         </span>
                     </div>
-                    {/if}
                 {/if}
             {/foreach}
 
             <table class="frontpage-license-info" style="width: 100%; border-collapse: collapse; margin-top: 0px;">
                 <tr>
                     <td style="width: 40px; vertical-align: middle;">
-                        {if isset($license_url) && isset($license_logo)}
                         {call name="getDoubleMetadata"
-                            preOne="<a href='" searchOne=$license_url postOne="'class='frontpage-anchor'>"
-                            preTwo="<img src='" searchTwo=$license_logo postTwo="'class='frontpage-license-image'></a>"
+                            preOne="<a href='" searchOne={$license_url} postOne="'class='frontpage-anchor'>"
+                            preTwo="<img src='" searchTwo={$license_logo} postTwo="'class='frontpage-license-image'></a>"
                         }
-                        {/if}
                     </td>
                     <td style="vertical-align: middle; padding-left: 10px;">
                         <div class="frontpage-license-text">
-                            {if isset($license_url) && isset($translations.$locale_key.license_text)}
                             {call name="getDoubleMetadata"
-                                preOne="<a href='" searchOne=$license_url postOne="' class='frontpage-anchor'>"
-                                preTwo="" searchTwo=$translations.$locale_key.license_text postTwo='</a>'
+                                preOne="<a href='" searchOne={$license_url} postOne="' class='frontpage-anchor'>"
+                                preTwo="" searchTwo="{$translations.{$locale_key}.license_text}" postTwo='</a>'
                             }
-                            {/if}
                         </div>
                     </td>
                 </tr>

--- a/templates/SUMARC/UNLP/frontpage.tpl
+++ b/templates/SUMARC/UNLP/frontpage.tpl
@@ -32,8 +32,8 @@
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
-                                        {call name="getMetadata" pre="{$translations.{$locale_key}.volume} " search={$issue_volume} post=", "}
-                                        {call name="getMetadata" pre="{$translations.{$locale_key}.number} " search={$issue_number} post=", "}
+                                        {if isset($translations.$locale_key.volume)}{call name="getMetadata" pre="{$translations.$locale_key.volume} " search={$issue_volume} post=", "}{/if}
+                                        {if isset($translations.$locale_key.number)}{call name="getMetadata" pre="{$translations.$locale_key.number} " search={$issue_number} post=", "}{/if}
                                         {call name="getMetadata" search={$publication_pages} post=", "}
                                         {call name="getMetadata" search={$section_title} post=", "}
                                         {call name="getMetadata" search={$issue_year}}
@@ -59,9 +59,9 @@
                                 </tr>
                                 <tr>
                                     <td class="frontpage-journal-info-line">
-                                        {call name="getMetadata" pre="{$translations.{$locale_key}.received}: " search={$date_submitted}}
-                                        {call name="getMetadata" pre=" - {$translations.{$locale_key}.accepted}: " search={$date_accepted}}
-                                        {call name="getMetadata" pre=" - {$translations.{$locale_key}.published}: " search={$date_published}}
+                                        {if isset($translations.$locale_key.received)}{call name="getMetadata" pre="{$translations.$locale_key.received}: " search={$date_submitted}}{/if}
+                                        {if isset($translations.$locale_key.accepted)}{call name="getMetadata" pre=" - {$translations.$locale_key.accepted}: " search={$date_accepted}}{/if}
+                                        {if isset($translations.$locale_key.published)}{call name="getMetadata" pre=" - {$translations.$locale_key.published}: " search={$date_published}}{/if}
                                     </td>
                                 </tr>
                             </table>
@@ -91,8 +91,8 @@
             {foreach from=$lang_keys item=key name=keys}
                 {if $locale_key != $key && ( (isset($titles.$key) && $titles.$key) || (isset($subtitles.$key) && $subtitles.$key) )}
                     <h5 class="frontpage-article-lang-title">
-                        {call name="getMetadata" pre="<span>" search=$titles.$key post="</span>."}
-                        {call name="getMetadata" pre="<span>" search=$subtitles.$key post="</span>"}
+                        {if isset($titles.$key)}{call name="getMetadata" pre="<span>" search=$titles.$key post="</span>."}{/if}
+                        {if isset($subtitles.$key)}{call name="getMetadata" pre="<span>" search=$subtitles.$key post="</span>"}{/if}
                     </h5>
                 {/if}
             {/foreach}
@@ -110,8 +110,8 @@
                                 </td>
                                 <td style="padding: 0; vertical-align: middle;">
                                     <div class="frontpage-author-name-colored">
-                                        {call name="getMetadata" search={$author.givenName.{$article_locale_key}}}
-                                        {call name="getMetadata" search={$author.familyName.{$article_locale_key}}}
+                                        {if isset($author.givenName.$article_locale_key)}{call name="getMetadata" search=$author.givenName.$article_locale_key}{/if}
+                                        {if isset($author.familyName.$article_locale_key)}{call name="getMetadata" search=$author.familyName.$article_locale_key}{/if}
                                     </div>
                                 </td>
                             </tr>
@@ -119,42 +119,50 @@
                         <div class="frontpage-author-contact">
                             {call name="getLinkedMetadata" preOne="<a href='mailto:'" preTwo="class='frontpage-anchor'>" search=$author.email post="</a>"}
                         </div>
-                        {call name="getMetadata" pre="<div class='frontpage-author-affiliation'>" search={$author.affiliation.{$article_locale_key}} post="</div>"}
+                        {if isset($author.affiliation.$article_locale_key)}{call name="getMetadata" pre="<div class='frontpage-author-affiliation'>" search=$author.affiliation.$article_locale_key post="</div>"}{/if}
                     </div>
                 {/foreach}
             </div>
 
             <hr class="frontpage-author-hr">
 
+            {if isset($abstract_texts.$locale_key)}
             <div class="frontpage-abstract-section">
                 <span>
-                    {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.{$locale_key}.abstract} | </span> <span class='frontpage-abstract-text'>" search={$abstract_texts.{$locale_key}} post="</span>"}
+                    {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.$locale_key.abstract} | </span> <span class='frontpage-abstract-text'>" search=$abstract_texts.$locale_key post="</span>"}
                 </span>
             </div>
+            {/if}
+            {if isset($keywords_texts.$locale_key)}
             <div class="frontpage-keywords-container">
-                {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.{$locale_key}.keywords} | </span>" search="{$keywords_texts.{$locale_key}}"}
+                {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.$locale_key.keywords} | </span>" search=$keywords_texts.$locale_key}
                 <span class="frontpage-keywords-list">
-                    {foreach from=$keywords_texts.{$locale_key} item=keyword name=keywords}
-                        {call name="getMetadata" pre="<span class='frontpage-keyword'>" search={$keyword} post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}
+                    {foreach from=$keywords_texts.$locale_key item=keyword name=keywords}
+                        {call name="getMetadata" pre="<span class='frontpage-keyword'>" search=$keyword post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}
                     {/foreach}
                 </span>
             </div>
+            {/if}
 
             {foreach from=$lang_keys item=key name=keys}
                 {if $locale_key != $key}
+                    {if isset($abstract_texts.$key)}
                     <div class="frontpage-abstract-section">
                         <span>
-                            {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.{$key}.abstract} | </span> <span class='frontpage-abstract-text'>" search={$abstract_texts.{$key}} post="</span>"}
+                            {call name="getMetadata" pre="<span class='frontpage-abstract-title'> {$translations.$key.abstract} | </span> <span class='frontpage-abstract-text'>" search=$abstract_texts.$key post="</span>"}
                         </span>
                     </div>
+                    {/if}
+                    {if isset($keywords_texts.$key)}
                     <div class="frontpage-keywords-container">
-                        {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.{$key}.keywords} | </span>" search="{$keywords_texts.{$key}}"}
+                        {call name="isMetadataSet" display="<span class='frontpage-keywords-label'> {$translations.$key.keywords} | </span>" search=$keywords_texts.$key}
                         <span class="frontpage-keywords-list">
-                            {foreach from=$keywords_texts.{$key} item=keyword name=keywords}
-                                {call name="getMetadata" pre="<span class='frontpage-keyword'>" search={$keyword} post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}
+                            {foreach from=$keywords_texts.$key item=keyword name=keywords}
+                                {call name="getMetadata" pre="<span class='frontpage-keyword'>" search=$keyword post="</span>{if !$smarty.foreach.keywords.last}, {/if}"}
                             {/foreach}
                         </span>
                     </div>
+                    {/if}
                 {/if}
             {/foreach}
 
@@ -168,10 +176,12 @@
                     </td>
                     <td style="vertical-align: middle; padding-left: 10px;">
                         <div class="frontpage-license-text">
+                            {if isset($translations.$locale_key.license_text)}
                             {call name="getDoubleMetadata"
                                 preOne="<a href='" searchOne={$license_url} postOne="' class='frontpage-anchor'>"
-                                preTwo="" searchTwo="{$translations.{$locale_key}.license_text}" postTwo='</a>'
+                                preTwo="" searchTwo="{$translations.$locale_key.license_text}" postTwo='</a>'
                             }
+                            {/if}
                         </div>
                     </td>
                 </tr>

--- a/templates/SUMARC/UNLP/header.tpl
+++ b/templates/SUMARC/UNLP/header.tpl
@@ -2,9 +2,9 @@
 
 <div class="header-container">
     <div class="header-metadata">
-        {call name="getMetadata" search={$journal_title} post=","} {call name="getMetadata" pre="Vol. " search={$issue_volume}} {call name="getMetadata" pre="Núm. " search={$issue_number}} {call name="getMetadata" pre="(" search={$issue_year} post=")"}
+        {if isset($journal_title)}{call name="getMetadata" search=$journal_title post=","}{/if} {if isset($issue_volume)}{call name="getMetadata" pre="Vol. " search=$issue_volume}{/if} {if isset($issue_number)}{call name="getMetadata" pre="Núm. " search=$issue_number}{/if} {if isset($issue_year)}{call name="getMetadata" pre="(" search=$issue_year post=")"}{/if}
     </div>
     <div>
-        {call name="getLinkedMetadata" preOne="<a class='header-linked-metadata' href='https://doi.org/" preTwo="' target='_blank'>https://doi.org/" search=$doi post="</a>"}
+        {if isset($doi)}{call name="getLinkedMetadata" preOne="<a class='header-linked-metadata' href='https://doi.org/" preTwo="' target='_blank'>https://doi.org/" search=$doi post="</a>"}{/if}
     </div>
 </div>

--- a/templates/SUMARC/UNLP/header.tpl
+++ b/templates/SUMARC/UNLP/header.tpl
@@ -2,9 +2,9 @@
 
 <div class="header-container">
     <div class="header-metadata">
-        {if isset($journal_title)}{call name="getMetadata" search=$journal_title post=","}{/if} {if isset($issue_volume)}{call name="getMetadata" pre="Vol. " search=$issue_volume}{/if} {if isset($issue_number)}{call name="getMetadata" pre="Núm. " search=$issue_number}{/if} {if isset($issue_year)}{call name="getMetadata" pre="(" search=$issue_year post=")"}{/if}
+        {call name="getMetadata" search={$journal_title} post=","} {call name="getMetadata" pre="Vol. " search={$issue_volume}} {call name="getMetadata" pre="Núm. " search={$issue_number}} {call name="getMetadata" pre="(" search={$issue_year} post=")"}
     </div>
     <div>
-        {if isset($doi)}{call name="getLinkedMetadata" preOne="<a class='header-linked-metadata' href='https://doi.org/" preTwo="' target='_blank'>https://doi.org/" search=$doi post="</a>"}{/if}
+        {call name="getLinkedMetadata" preOne="<a class='header-linked-metadata' href='https://doi.org/" preTwo="' target='_blank'>https://doi.org/" search=$doi post="</a>"}
     </div>
 </div>

--- a/templates/SUMARC/UNLP/references.tpl
+++ b/templates/SUMARC/UNLP/references.tpl
@@ -6,4 +6,4 @@
 
 <break />
 
-<h2 class="references-title">{$translations.{$locale_key}.references}</h2>
+<h2 class="references-title">{if isset($translations.$locale_key.references)}{$translations.$locale_key.references}{/if}</h2>

--- a/templates/SUMARC/UNLP/references.tpl
+++ b/templates/SUMARC/UNLP/references.tpl
@@ -6,4 +6,4 @@
 
 <break />
 
-<h2 class="references-title">{if isset($translations.$locale_key.references)}{$translations.$locale_key.references}{/if}</h2>
+<h2 class="references-title">{$translations.{$locale_key}.references}</h2>


### PR DESCRIPTION
## Fix: hardening de JatsParser para PHP 8 (null-safety, Smarty compile dir, citationStyle fallback y fixes de rendering)

### Contexto

Este PR corrige múltiples errores detectados durante el pasaje a producción de SUMARCv2.

Los problemas estaban asociados a:

* Cambios de comportamiento en PHP 8 (warnings por null y offsets inválidos)
* Manejo incorrecto de valores nulos en backend y templates
* Configuración incorrecta de Smarty
* Acceso inconsistente a settings del plugin

Estos errores provocaban warnings, errores fatales y fallos en la generación de HTML/PDF.

---

## Cambios incluidos

### 1. Null-safety en fecha de publicación

**Archivo:** `JatsParserPlugin.inc.php`

* Se elimina el uso de `list()` sobre `explode()` sin validación
* Se agrega control cuando `getDatePublished()` retorna `null`
* Se utiliza acceso seguro con `??`

**Impacto:**

* Evita `Undefined array key`
* Previene fallos en generación de PDF

---

### 2. Fix en renderizado (Smarty)

**Archivo:** `templates/.../frontpage.tpl`

* Se evita acceso a offsets sobre `null`
* Se reemplaza `{$subtitles.{$locale_key}}` por `$subtitles.$locale_key`, por ejemplo
* Se agrega validación con `isset()` antes de llamar a `getMetadata`

**Impacto:**

* Elimina `Trying to access array offset on null`
* Mejora compatibilidad con PHP 8

---

### 3. Inicialización segura de footnotes

**Archivo:** `HTMLProcessingService.php`

* Se inicializa `$footnotes = []` en `setFootnotesAnchors()`

**Impacto:**

* Evita retorno de `null`
* Previene error en `foreach()`
* Consistencia con `setReferencesAnchors()`

---

### 4. Fix de citationStyle null (TypeError)

**Archivos:**

* `JatsParserPlugin.inc.php`

* `PDFOutputStrategy.php`

* `HTMLOutputStrategy.php`

* Se reemplaza:

  ```php
  getSetting('citationStyle')
  ```

  por:

  ```php
  getCitationStyle(...)
  ```

**Impacto:**

* Evita `TypeError` cuando el setting está vacío
* Usa fallback existente (`vancouver`)
* Elimina duplicación de lógica

---

### 5. Reubicación de templates compilados (Smarty)

**Archivos:**

* `PDFOutputStrategy.php`

* `HTMLOutputStrategy.php`

* Se configura `compile_dir` para usar:

  ```
  cache/t_compile/
  ```

**Impacto:**

* Corrige errores de permisos en producción
* Evita uso de `templates_c` en la raíz
* Mejora seguridad

---

### 6. Validaciones adicionales de metadata

* Se agregan verificaciones antes de llamar a `getMetadata`

**Impacto:**

* Evita errores cuando faltan datos opcionales
* Reduce warnings en templates

---

## Notas de configuración

El plugin requiere que la función `finfo_open()` esté habilitada.

Si está deshabilitada en `php.ini`:

```
disable_functions = finfo_open
```

Provoca error fatal.

**Acción requerida:**

* Remover `finfo_open` de `disable_functions` en PHP-FPM

---

## Resultado

* Compatibilidad con PHP 8
* Eliminación de warnings y errores fatales
* Mayor tolerancia a datos incompletos
* Configuración correcta de Smarty
* Acceso consistente a settings del plugin
